### PR TITLE
Fix an error when no state defined on component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export default {
     if(__DEV__) { // typecheck parameters in dev mode
       name.should.be.a.String;
     }
-    return this.state[privateSymbol(`animation${name}`)] || {};
+    return this.state && this.state[privateSymbol(`animation${name}`)] || {};
   },
 
   isAnimated(name) {


### PR DESCRIPTION
When the main component has no state defined and no animation is started, the call to  `getAnimatedStyle` fails silently.